### PR TITLE
feat: post code update now does not sync database and files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,32 @@
 # Acquia Cloud Hooks
 
-Automated deployment hooks for Acquia Cloud Platform. These hooks run in response to code deployments and commits, handling database/file synchronization, Drupal deployment steps, and Varnish cache clearing.
+Automated deployment hooks for Acquia Cloud Platform. These hooks run in response to code deployments and commits, handling Drupal deployment steps and Varnish cache clearing. The `post-code-deploy` hook also handles database/file synchronization.
 
 ## How It Works
 
-Acquia Cloud Hooks are shell scripts that Acquia automatically executes when certain events occur in your environment. This package provides two hooks:
+Acquia Cloud Hooks are shell scripts that Acquia automatically executes when certain events occur in your environment. This package provides two hooks with different responsibilities:
 
 | Hook | Trigger | Script |
 |---|---|---|
 | `post-code-deploy` | A tag or branch is deployed to an environment | `common/post-code-deploy/build.sh` |
 | `post-code-update` | A commit is pushed to a branch currently deployed to an environment | `common/post-code-update/build.sh` |
 
-> **Note:** `common/post-code-update/build.sh` is a symlink pointing to `common/post-code-deploy/build.sh`. Both hooks run the exact same script — any changes made to `post-code-deploy/build.sh` are automatically reflected in `post-code-update`.
+## What Each Hook Does
 
-## What the Build Script Does
+Both hooks share these steps:
 
-On each deployment, the build script:
+1. **Skip the RA environment** — the Release Agent environment is always bypassed.
+2. **Check for a `skipbuild` file** — if present, exits immediately (see below).
+3. **Authenticate** with the Acquia Cloud API via ACLI.
+4. **Run deployment commands** via `helper/deploy.sh` (or a custom script if one exists).
+5. **Clear Varnish caches** for all active domains in the environment.
 
-1. **Skips the RA environment** — the Release Agent environment is always bypassed.
-2. **Checks for a `skipbuild` file** — if present, exits immediately (see below).
-3. **Authenticates** with the Acquia Cloud API via ACLI.
-4. **Syncs data** from the canonical environment (default: `prod`):
-   - On non-canonical environments: copies the database and files from `prod` (runs concurrently).
-   - On the canonical environment: creates a database backup before deploying.
-5. **Runs deployment commands** via `helper/deploy.sh` (or a custom script if one exists).
-6. **Clears Varnish caches** for all active domains in the environment.
+### post-code-deploy only
+
+In addition to the shared steps, `post-code-deploy` also **syncs data** from the canonical environment (default: `prod`):
+
+- On non-canonical environments: copies the database and files from `prod` (runs concurrently).
+- On the canonical environment: creates a database backup before deploying.
 
 ### Default Deploy Script
 
@@ -69,7 +71,7 @@ Generate API tokens at: https://docs.acquia.com/cloud-platform/develop/api/auth/
 
 ### 3. Configuration Variables
 
-The following variables can be adjusted at the top of `common/post-code-deploy/build.sh`:
+**`common/post-code-deploy/build.sh`** (data sync variables):
 
 | Variable | Default | Description |
 |---|---|---|
@@ -77,6 +79,8 @@ The following variables can be adjusted at the top of `common/post-code-deploy/b
 | `ACQUIA_DATABASE_NAME` | `$site` | Database name to backup/copy |
 | `ACLI_MAX_TIMEOUT` | `600` | Max seconds to wait for async API operations |
 | `ACLI_DELAY` | `15` | Seconds between API status checks |
+
+These variables are not present in `post-code-update` as it does not perform data sync.
 
 ## Skipping a Build
 

--- a/common/post-code-update/build.sh
+++ b/common/post-code-update/build.sh
@@ -1,1 +1,86 @@
-../post-code-deploy/build.sh
+#!/bin/bash
+#
+# Cloud Hook (common): post-code-update
+#
+# The post-code-update hook runs in response to code commits.
+# When you push commits to a Git branch, the post-code-update hooks runs for
+# each environment that is currently running that branch. See
+# ../README.md for details.
+#
+# Usage: post-code-update site target-env source-branch deployed-tag repo-url
+#                         repo-type
+
+site="$1"
+target_env="$2"
+
+# Do not interfere with the RA environment
+if [ "$target_env" == "ra" ]; then
+  exit
+fi
+
+# You must set up the following variables in
+# /mnt/gfs/home/$site/$target_env/nobackup/bashkeys.sh
+#
+# - `ACQUIACLI_KEY`
+#    Cloud API Private key generated when you generate a token.
+#    See: https://docs.acquia.com/cloud-platform/develop/api/auth/#cloud-generate-api-token
+# - `ACQUIACLI_SECRET`
+#    Cloud API secret generated when you generate a token.
+
+# `AH_REALM` should be provided by the acquia environment
+# see: https://docs.acquia.com/acquia-cloud/develop/env-variable/#available-environment-variables
+if [ -z "$AH_REALM" ]
+then
+  echo "The REALM is not set."
+  exit 1;
+fi
+
+# Grab Keys
+# @see https://docs.acquia.com/acquia-cloud-platform/manage-apps/files/system-files/private
+source /mnt/gfs/home/$site/$target_env/nobackup/bashkeys.sh
+
+if [ -z "$ACQUIACLI_KEY" ] || [ -z "$ACQUIACLI_SECRET" ]
+then
+  echo "There are no keys set up for this environment."
+  exit 1;
+fi
+
+if [ -f "/mnt/gfs/home/$site/$target_env/nobackup/skipbuild" ]; then
+  echo "The skip file was detected. You must run backups and build commands manually."
+  exit 0;
+fi
+PROJECT_ROOT="$( dirname "$0" )/../../.."
+pushd "$PROJECT_ROOT" || exit 1
+acli_path="$(realpath ./vendor/bin/acli)"
+acli="$acli_path -n"
+HELPER_SCRIPT_PATH="$( dirname "$0" )/../../helper"
+
+# Login to the Acquia API.
+$acli auth:login -k "$ACQUIACLI_KEY" -s "$ACQUIACLI_SECRET"
+
+popd || exit 1
+
+echo "Starting Build for $target_env"
+
+# Every environment builds like if it was production.
+
+if [[ -f "$PROJECT_ROOT/scripts/custom/deploy.sh" ]]; then
+echo "Running custom deployment script."
+  "$PROJECT_ROOT/scripts/custom/deploy.sh" "$target_env"
+else
+  "$HELPER_SCRIPT_PATH/deploy.sh" "$target_env"
+fi
+
+pushd "$PROJECT_ROOT" || exit 1
+
+echo "Finding domains that use Varnish."
+DOMAINS="$( ACLI_COMMAND="$acli" php "$HELPER_SCRIPT_PATH/get-env-domains.php" "$site.$target_env" )"
+echo "Clearing Varnish cache for $DOMAINS"
+# DOMAINS is an argument list. Purposfully not quoting it.
+TMP_FILE=$(mktemp --suffix=.json)
+$acli api:environments:clear-caches "$site.$target_env" $DOMAINS > "$TMP_FILE"
+ACLI_MAX_TIMEOUT=60 ACLI_DELAY=5 ACLI_COMMAND="$acli" php "$HELPER_SCRIPT_PATH/wait-for-notification.php" "$TMP_FILE"
+
+popd || exit 1
+
+echo "Ending Build for $target_env"


### PR DESCRIPTION
The post-code-update/build.sh script was simply a symlink to the post-code-deploy/build.sh script.

Instead of resyncing the environment on code updates, where we often want to keep the database and files, as well as save the time from syncing them, we will just run drupal deployment steps (updates, config import, cache clears). In the case where one does want new database and files, then you can still use the acquia UI or other methods to sync files and db to the environment and then run deployment steps manually.